### PR TITLE
DSOC9-124 # Updated manifests

### DIFF
--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   image: quay.io/prometheus/alertmanager:v0.20.0
   nodeSelector:
+    role: prometheus
     kubernetes.io/os: linux
   replicas: 3
   securityContext:

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -8,16 +8,15 @@ stringData:
   alertmanager.yaml: |-
     "global":
       "resolve_timeout": "5m"
+      "slack_api_url": 'https://hooks.slack.com/services/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'
     "inhibit_rules":
     - "equal":
-      - "namespace"
       - "alertname"
       "source_match":
         "severity": "critical"
       "target_match_re":
         "severity": "warning|info"
     - "equal":
-      - "namespace"
       - "alertname"
       "source_match":
         "severity": "warning"
@@ -25,20 +24,53 @@ stringData:
         "severity": "info"
     "receivers":
     - "name": "Default"
+      "slack_configs":
+      - "channel": '#dso-k8s-sharedsvc-alerts'
+        "api_url": 'https://hooks.slack.com/services/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'
+        "send_resolved": true
+        "title": |-
+          [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]🔥 {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}
+          {{- if gt (len .CommonLabels) (len .GroupLabels) -}}
+            {{" "}}(
+            {{- with .CommonLabels.Remove .GroupLabels.Names }}
+              {{- range $index, $label := .SortedPairs -}}
+                {{ if $index }}, {{ end }}
+                {{- $label.Name }}="{{ $label.Value -}}"
+              {{- end }}
+            {{- end -}}
+            )
+          {{- end }}
+        "text": >-
+          {{ with index .Alerts 0 -}}
+            :chart_with_upwards_trend: *<{{ .GeneratorURL }}|Graph>*
+            {{- if .Annotations.runbook }}   :notebook: *<{{ .Annotations.runbook }}|Runbook>*{{ end }}
+          {{ end }}
+
+          *Alert details*: sharedsvc-cluster
+
+          {{ range .Alerts -}}
+          *Alert:* {{ .Annotations.title }}{{ if .Labels.severity }} - `{{ .Labels.severity }}`{{ end }}
+          *Summary:* {{ .Annotations.description }}
+          *Details:*
+            {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+            {{ end }}
+          {{ end }}
     - "name": "Watchdog"
     - "name": "Critical"
     "route":
       "group_by":
-      - "namespace"
+      - "alertname"
+      - "pod"
+      - "job"
       "group_interval": "5m"
       "group_wait": "30s"
       "receiver": "Default"
-      "repeat_interval": "12h"
+      "repeat_interval": "1h"
       "routes":
       - "match":
           "alertname": "Watchdog"
-        "receiver": "Watchdog"
+        "receiver": "Default"
       - "match":
           "severity": "critical"
-        "receiver": "Critical"
+        "receiver": "Default"
 type: Opaque

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -113,6 +113,7 @@ spec:
           name: grafana-dashboard-workload-total
           readOnly: false
       nodeSelector:
+        role: prometheus
         beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
-      hostNetwork: true
+      #hostNetwork: true
       hostPID: true
       nodeSelector:
         kubernetes.io/os: linux

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -40,6 +40,7 @@ spec:
           name: config
           readOnly: false
       nodeSelector:
+        role: prometheus
         kubernetes.io/os: linux
       serviceAccountName: prometheus-adapter
       volumes:

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -6,6 +6,41 @@ metadata:
   name: k8s
   namespace: monitoring
 spec:
+  containers:
+  - name: prometheus
+    args:
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--config.file=/etc/prometheus/config_out/prometheus.env.yaml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=24h'
+      - '--web.enable-lifecycle'
+      - '--storage.tsdb.no-lockfile'
+      - '--web.route-prefix=/'
+      - '--storage.tsdb.max-block-duration=2m'
+      - '--storage.tsdb.min-block-duration=2m'
+    livenessProbe:
+      failureThreshold: 6
+      httpGet:
+        path: /-/healthy
+        port: http
+        scheme: HTTP
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
+    ports:
+    - containerPort: 9090
+      name: http
+      protocol: TCP
+    readinessProbe:
+      failureThreshold: 120
+      httpGet:
+        path: /-/ready
+        port: http
+        scheme: HTTP
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 3
   alerting:
     alertmanagers:
     - name: alertmanager-main
@@ -13,6 +48,7 @@ spec:
       port: web
   image: quay.io/prometheus/prometheus:v2.17.2
   nodeSelector:
+    role: prometheus
     kubernetes.io/os: linux
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
@@ -31,4 +67,10 @@ spec:
   serviceAccountName: prometheus-k8s
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector: {}
+  thanos:
+    baseImage: quay.io/thanos/thanos
+    objectStorageConfig:
+      key: thanos.yaml
+      name: thanos-objectstorage
+    version: v0.7.0
   version: v2.17.2

--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: monitoring
 spec:
   ports:
-  - name: web
+  - name: http
     port: 9090
-    targetPort: web
+    targetPort: http
   selector:
     app: prometheus
     prometheus: k8s

--- a/manifests/prometheus-serviceMonitor.yaml
+++ b/manifests/prometheus-serviceMonitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - interval: 30s
-    port: web
+    port: http
   selector:
     matchLabels:
       prometheus: k8s

--- a/manifests/setup/prometheus-operator-deployment.yaml
+++ b/manifests/setup/prometheus-operator-deployment.yaml
@@ -53,6 +53,7 @@ spec:
         securityContext:
           runAsUser: 65534
       nodeSelector:
+        role: prometheus
         beta.kubernetes.io/os: linux
       securityContext:
         runAsNonRoot: true

--- a/manifests/thanos-objectstorage.yaml
+++ b/manifests/thanos-objectstorage.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  thanos.yaml: dHlwZTogczMKY29uZmlnOgogIGJ1Y2tldDogc2Vjb3BzLWRldi1zdGFzaC1tZXRyaWNzCiAgZW5kcG9pbnQ6IHMzLmFtYXpvbmF3cy5jb20KICBlbmNyeXB0c3NlOiB0cnVlCiAgYWNjZXNzX2tleTogQUtJQVY3MllMRU9BNkdMWTVBUzQKICBzZWNyZXRfa2V5OiBNd1JWZy9KSXgvN3dTQVVpMTkyR2laMExodDdzQnBxYkRZaGZ5M3E0Cg==
+kind: Secret
+metadata:
+  name: thanos-objectstorage
+  namespace: monitoring
+type: Opaque


### PR DESCRIPTION
These are the modified manifests from the kube-prometheus repo which I would like you to have a look and comment if any queries.

0. Changes made to prometheus-prometheus.yaml
containers:

name: prometheus
args:
'--web.console.templates=/etc/prometheus/consoles'
'--web.console.libraries=/etc/prometheus/console_libraries'
'--config.file=/etc/prometheus/config_out/prometheus.env.yaml'
'--storage.tsdb.path=/prometheus'
'--storage.tsdb.retention.time=24h'
'--web.enable-lifecycle'
'--storage.tsdb.no-lockfile'
'--web.route-prefix=/'
'--storage.tsdb.max-block-duration=2m'
'--storage.tsdb.min-block-duration=2m'
livenessProbe:
failureThreshold: 6
httpGet:
path: /-/healthy
port: http
scheme: HTTP
periodSeconds: 5
successThreshold: 1
timeoutSeconds: 3
ports:
containerPort: 9090
name: http
protocol: TCP
readinessProbe:
failureThreshold: 120
httpGet:
path: /-/ready
port: http
scheme: HTTP
periodSeconds: 5
successThreshold: 1
timeoutSeconds: 3
1. portname change from web to http
prometheus-prometheus.yaml
prometheus-service.yaml
prometheus-serviceMonitor.yaml

2. Added nodeSelector in the below manifests
  nodeSelector:
     role: prometheus 
alertmanager-alertmanager.yaml
grafana-deployment.yaml
prometheus-adapter-deployment.yaml
setup/prometheus-operator-deployment.yaml

3. commented hostNetwork = true (means disabled)
spec.containers.hostNetwork: true

node-exporter-daemonset.yaml

4. Added extra to the repo (to store metrics to s3 bucket)
thanos-objectstorage.yaml

5. Updated alertmanager-secret.yaml with slack channel 