### PR TITLE
DSOC9-124 # Removed slack_api_url from alertmanager-secret.yaml for now

### DIFF
--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -8,7 +8,7 @@ stringData:
   alertmanager.yaml: |-
     "global":
       "resolve_timeout": "5m"
-      "slack_api_url": 'https://hooks.slack.com/services/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'
+      "slack_api_url": 'https://xxxx need to be replaced xxxx'
     "inhibit_rules":
     - "equal":
       - "alertname"
@@ -26,7 +26,7 @@ stringData:
     - "name": "Default"
       "slack_configs":
       - "channel": '#dso-k8s-sharedsvc-alerts'
-        "api_url": 'https://hooks.slack.com/services/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'
+        "api_url": 'https://xxxx need to be replaced xxxx'
         "send_resolved": true
         "title": |-
           [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]🔥 {{ .CommonLabels.alertname }} for {{ .CommonLabels.job }}


### PR DESCRIPTION
Due to security reasons, Removed slack_api_url from alertmanager-secret.yaml for now